### PR TITLE
use column names of X1, X2 as names for beta1, beta2

### DIFF
--- a/inst/tinytest/test_two_group_mixed.R
+++ b/inst/tinytest/test_two_group_mixed.R
@@ -195,3 +195,26 @@ for (i in 1:n_runs) {
 }
 expect_true(sum(has_NaNs) == 0)
 
+
+
+# test informative row names ----------------------------------------------
+
+# if X1, X2 have column names they should be used as row names for beta1, beta2 results
+
+X1_named <- stats::model.matrix(~ 0 + as.factor(cyl), data = mtcars)
+X2_named <- stats::model.matrix(~ wt + as.factor(gear), data = mtcars)
+fit <- fit_two_group_mixed(
+  y = mtcars$mpg,
+  X1_named,
+  X2_named,
+  ss = 10,
+  sd1 = 5,
+  sd_y = 10,
+  nnt = 30
+)
+expect_equal(rownames(fit$beta1), colnames(X1_named))
+expect_equal(rownames(fit$beta2), colnames(X2_named))
+expect_equal(rownames(fit$cov), c(colnames(X1_named), colnames(X2_named)))
+expect_equal(colnames(fit$cov), rownames(fit$cov))
+expect_equal(rownames(fit$errors), c(rownames(fit$beta1), rownames(fit$beta2), "sigma_y", "sigma_beta1"))
+

--- a/inst/tinytest/test_two_group_mixed.R
+++ b/inst/tinytest/test_two_group_mixed.R
@@ -230,8 +230,8 @@ fit <- fit_two_group_mixed(
   nnt = 30
 )
 expect_equal(rownames(fit$beta1), colnames(X1_named))
-expect_equal(rownames(fit$beta2), colnames(X2_unnamed))
-expect_equal(rownames(fit$cov), c(colnames(X1_named), colnames(X2_unnamed)))
+expect_equal(rownames(fit$beta2), paste0("beta2", "_", 1:nrow(fit$beta2)))
+expect_equal(rownames(fit$cov), c(rownames(fit$beta1), rownames(fit$beta2)))
 expect_equal(colnames(fit$cov), rownames(fit$cov))
 expect_equal(rownames(fit$errors), c(rownames(fit$beta1), rownames(fit$beta2), "sigma_y", "sigma_beta1"))
 

--- a/inst/tinytest/test_two_group_mixed.R
+++ b/inst/tinytest/test_two_group_mixed.R
@@ -218,3 +218,20 @@ expect_equal(rownames(fit$cov), c(colnames(X1_named), colnames(X2_named)))
 expect_equal(colnames(fit$cov), rownames(fit$cov))
 expect_equal(rownames(fit$errors), c(rownames(fit$beta1), rownames(fit$beta2), "sigma_y", "sigma_beta1"))
 
+X2_unnamed <- X2_named
+colnames(X2_unnamed) <- NULL
+fit <- fit_two_group_mixed(
+  y = mtcars$mpg,
+  X1_named,
+  X2_unnamed,
+  ss = 10,
+  sd1 = 5,
+  sd_y = 10,
+  nnt = 30
+)
+expect_equal(rownames(fit$beta1), colnames(X1_named))
+expect_equal(rownames(fit$beta2), colnames(X2_unnamed))
+expect_equal(rownames(fit$cov), c(colnames(X1_named), colnames(X2_unnamed)))
+expect_equal(colnames(fit$cov), rownames(fit$cov))
+expect_equal(rownames(fit$errors), c(rownames(fit$beta1), rownames(fit$beta2), "sigma_y", "sigma_beta1"))
+

--- a/man/fit_two_group_mixed.Rd
+++ b/man/fit_two_group_mixed.Rd
@@ -38,11 +38,13 @@ direction as described in Greengard et al. (2022).}
 A named list with the following components:
 \itemize{
 \item \code{beta1}: A data frame with two columns (\code{mean}, \code{sd}) containing the
-posterior means and standard deviations for the vector \eqn{\beta_1} (the
-coefficients on \code{X1}).
+posterior means and standard deviations for the vector \eqn{\beta_1}. If \code{X1}
+has column names they are used as the row names for \code{beta1}, otherwise
+generic names are used (\code{beta1_1}, \code{beta1_2}, etc.).
 \item \code{beta2}: A data frame with two columns (\code{mean}, \code{sd})  containing the
-posterior means and standard deviations for the vector \eqn{\beta_2} (the
-coefficients on \code{X2}).
+posterior means and standard deviations for the vector \eqn{\beta_2}. If \code{X2}
+has column names they are used as the row names for \code{beta2}, otherwise
+generic names are used (\code{beta2_1}, \code{beta2_2}, etc.).
 \item \code{sigma}: A data frame with two columns (\code{mean}, \code{sd}) containing the
 posterior means and standard deviations for \eqn{\sigma_y} and \eqn{\sigma_1}.
 \item \code{cov}: The posterior covariance matrix of coefficients \eqn{[\beta_1, \beta_2]}.
@@ -69,7 +71,7 @@ matrix. The algorithm for computing the fit uses numerical linear algebra and
 low dimensional Gaussian quadrature. See Greengard et al. (2022) for details.
 }
 \examples{
-# Simulate data
+### Example with simulated data
 set.seed(1)
 n <- 1000
 k1 <- 50
@@ -91,6 +93,26 @@ str(fit)
 # Plot estimates of the betas vs "truth"
 plot(fit$beta1$mean, beta1, pch = 20); abline(0, 1, col = "red")
 plot(fit$beta2$mean, beta2, pch = 20); abline(0, 1, col = "red")
+
+
+### Example of varying intercept model using mtcars dataset
+
+# suppose we want to fit the following model (in lme4 syntax)
+# using the mtcars dataset that comes with R:
+#   mpg ~ wt + as.factor(gear) + (1|cyl)
+
+fit <- fit_two_group_mixed(
+  y = mtcars$mpg,
+  X1 = stats::model.matrix(~ 0 + as.factor(cyl), data = mtcars),
+  X2 = stats::model.matrix(~ wt + as.factor(gear), data = mtcars),
+  ss = 10,
+  sd1 = 5,
+  sd_y = 10,
+  nnt = 30
+)
+fit$beta1
+fit$beta2
+fit$sigma
 
 }
 \references{


### PR DESCRIPTION
If X1 and/or X2 has column names those names will be used as the row names in the data frames in the fitted model object. For example: 

```r
fit <- fit_two_group_mixed(
  y = mtcars$mpg,
  X1 = stats::model.matrix(~ 0 + as.factor(cyl), data = mtcars),
  X2 = stats::model.matrix(~ wt + as.factor(gear), data = mtcars),
  ss = 10,
  sd1 = 5,
  sd_y = 10,
  nnt = 30
)
fit$beta1
fit$beta2
```

```
> fit$beta1
                      mean       sd
as.factor(cyl)4  2.2652288 2.535426
as.factor(cyl)6 -0.7714867 2.360611
as.factor(cyl)8 -1.4465161 2.507417
```

```
> fit$beta2
                       mean        sd
(Intercept)      32.1904517 3.8806793
wt               -3.8473987 0.9037608
as.factor(gear)4  1.1571735 1.6170306
as.factor(gear)5 -0.8548444 1.6863203
```