### PR TITLE
make user specify prior scale values

### DIFF
--- a/R/fit_mixed.R
+++ b/R/fit_mixed.R
@@ -23,16 +23,12 @@
 #'   model. Must have `length(y)` rows.
 #' @param ... Currently for internal use only.
 #' @param sd_sigma_y (positive real) Scale parameter value for the prior on
-#'   \eqn{\sigma_y}. The default is `1`, but we strongly recommend setting the
-#'   value yourself.
+#'   \eqn{\sigma_y}.
 #' @param sd_sigma1 (positive real) Scale parameter value for the prior on
-#'   \eqn{\sigma1}. The default is `1`, but we strongly recommend setting the
-#'   value yourself.
+#'   \eqn{\sigma1}.
 #' @param sd_beta2 (positive reals) Scale parameter values for the priors on
 #'   \eqn{\beta2} ("fixed effects" coefficients). Must have either one element
-#'   or `ncol(X2)` elements. In the former case the value is recycled. The
-#'   default is `1` for each element, but we strongly recommend setting the
-#'   values yourself.
+#'   or `ncol(X2)` elements. In the former case the value is recycled.
 #' @param nnt (positive integer) Number of quadrature nodes in \eqn{\theta}
 #'   direction as described in Greengard et al. (2022). We recommend increasing
 #'   `nnt` to improve the accuracy of the estimates if the errors are too large
@@ -117,7 +113,7 @@
 #' fit$sigma
 #'
 fit_mixed <- function(y, X1, X2, ...,
-                      sd_sigma_y = 1, sd_sigma1 = 1, sd_beta2 = rep(1, ncol(X2)),
+                      sd_sigma_y, sd_sigma1, sd_beta2,
                       nnt = 10) {
   stopifnot(
     !anyNA(y),

--- a/R/fit_mixed_formula.R
+++ b/R/fit_mixed_formula.R
@@ -43,7 +43,7 @@
 #' fit$errors
 #'
 fit_mixed_formula <- function(formula, data, ...,
-                              sd_sigma_y = 1, sd_sigma1 = 1, sd_beta2 = 1,
+                              sd_sigma_y, sd_sigma1, sd_beta2,
                               nnt = 10) {
   stopifnot(
     is.data.frame(data),

--- a/inst/tinytest/answers/fit_mixed-01.R
+++ b/inst/tinytest/answers/fit_mixed-01.R
@@ -4269,4 +4269,4 @@ list(beta1 = structure(list(mean = c(-0.28811338241106843, -0.10907418998909149,
     "beta2_45", "beta2_46", "beta2_47", "beta2_48", "beta2_49", 
     "beta2_50", "beta2_51", "beta2_52", "beta2_53", "beta2_54", 
     "beta2_55", "beta2_56", "beta2_57", "beta2_58", "beta2_59", 
-    "beta2_60", "sigma_y", "sigma_beta1")), time = 0.056335573999999999)
+    "beta2_60", "sigma_y", "sigma_beta1")), time = 0.059861022)

--- a/inst/tinytest/answers/fit_mixed-02.R
+++ b/inst/tinytest/answers/fit_mixed-02.R
@@ -4269,4 +4269,4 @@ list(beta1 = structure(list(mean = c(-0.28812167802745148, -0.10907740878346232,
     "beta2_45", "beta2_46", "beta2_47", "beta2_48", "beta2_49", 
     "beta2_50", "beta2_51", "beta2_52", "beta2_53", "beta2_54", 
     "beta2_55", "beta2_56", "beta2_57", "beta2_58", "beta2_59", 
-    "beta2_60", "sigma_y", "sigma_beta1")), time = 0.062138959000000001)
+    "beta2_60", "sigma_y", "sigma_beta1")), time = 0.062076855)

--- a/inst/tinytest/answers/fit_mixed-03.R
+++ b/inst/tinytest/answers/fit_mixed-03.R
@@ -4269,4 +4269,4 @@ list(beta1 = structure(list(mean = c(-0.28811752740663504, -0.10907529575535664,
     "beta2_45", "beta2_46", "beta2_47", "beta2_48", "beta2_49", 
     "beta2_50", "beta2_51", "beta2_52", "beta2_53", "beta2_54", 
     "beta2_55", "beta2_56", "beta2_57", "beta2_58", "beta2_59", 
-    "beta2_60", "sigma_y", "sigma_beta1")), time = 0.472058223)
+    "beta2_60", "sigma_y", "sigma_beta1")), time = 0.29764264500000004)

--- a/inst/tinytest/test_fit_mixed.R
+++ b/inst/tinytest/test_fit_mixed.R
@@ -23,42 +23,42 @@ X_1_NA[1,1] <- NA
 X_2_NA[1,1] <- NA
 
 expect_error(
-  fit_mixed(y_NA, X_1, X_2),
+  fit_mixed(y_NA, X_1, X_2, sd_sigma_y = 1, sd_sigma1 = 1, sd_beta2 = 1),
   "!anyNA(y) is not TRUE",
   fixed = TRUE
 )
 expect_error(
-  fit_mixed(y, X_1_NA, X_2),
+  fit_mixed(y, X_1_NA, X_2, sd_sigma_y = 1, sd_sigma1 = 1, sd_beta2 = 1),
   "!anyNA(X1) is not TRUE",
   fixed = TRUE
 )
 expect_error(
-  fit_mixed(y, X_1, X_2_NA),
+  fit_mixed(y, X_1, X_2_NA, sd_sigma_y = 1, sd_sigma1 = 1, sd_beta2 = 1),
   "!anyNA(X2) is not TRUE",
   fixed = TRUE
 )
 expect_error(
-  fit_mixed(y, X_1, X_2, sd_beta2 = -1),
+  fit_mixed(y, X_1, X_2, sd_beta2 = -1, sd_sigma_y = 1, sd_sigma1 = 1),
   "all(sd_beta2 > 0) is not TRUE",
   fixed = TRUE
 )
 expect_error(
-  fit_mixed(y, X_1, X_2, sd_sigma_y = -1),
+  fit_mixed(y, X_1, X_2, sd_sigma_y = -1, sd_sigma1 = 1, sd_beta2 = 1),
   "sd_sigma_y > 0 is not TRUE",
   fixed = TRUE
 )
 expect_error(
-  fit_mixed(y, X_1, X_2, sd_sigma1 = -1),
+  fit_mixed(y, X_1, X_2, sd_sigma1 = -1, sd_sigma_y = 1, sd_beta2 = 1),
   "sd_sigma1 > 0 is not TRUE",
   fixed = TRUE
 )
 expect_error(
-  fit_mixed(y, X_1, X_2, nnt = -20),
+  fit_mixed(y, X_1, X_2, nnt = -20, sd_sigma_y = 1, sd_sigma1 = 1, sd_beta2 = 1),
   "nnt > 0 is not TRUE",
   fixed = TRUE
 )
 expect_error(
-  fit_mixed(y, X_1, X_2, nnt = pi),
+  fit_mixed(y, X_1, X_2, nnt = pi, sd_sigma_y = 1, sd_sigma1 = 1, sd_beta2 = 1),
   "nnt == as.integer(nnt) is not TRUE",
   fixed = TRUE
 )
@@ -66,44 +66,44 @@ expect_error(
 
 # incorrect sizes
 expect_error(
-  fit_mixed(y[-1], X_1, X_2),
+  fit_mixed(y[-1], X_1, X_2, sd_sigma_y = 1, sd_sigma1 = 1, sd_beta2 = 1),
   "length(y) == nrow(X1) is not TRUE",
   fixed = TRUE
 )
 expect_error(
-  fit_mixed(y, X_1[-1, ], X_2),
+  fit_mixed(y, X_1[-1, ], X_2, sd_sigma_y = 1, sd_sigma1 = 1, sd_beta2 = 1),
   "nrow(X1) == nrow(X2) is not TRUE",
   fixed = TRUE
 )
 expect_error(
-  fit_mixed(y, X_1, X_2[-1, ]),
+  fit_mixed(y, X_1, X_2[-1, ], sd_sigma_y = 1, sd_sigma1 = 1, sd_beta2 = 1),
   "nrow(X1) == nrow(X2) is not TRUE",
   fixed = TRUE
 )
 expect_error(
-  fit_mixed(y, X_1, X_2, sd_beta2 = c(1, 2, 3)),
+  fit_mixed(y, X_1, X_2, sd_beta2 = c(1, 2, 3), sd_sigma_y = 1, sd_sigma1 = 1),
   "length(sd_beta2) == 1 || length(sd_beta2) == ncol(X2) is not TRUE",
   fixed = TRUE
 )
 expect_error(
-  fit_mixed(y, X_1, X_2, sd_sigma_y = c(1, 2)),
+  fit_mixed(y, X_1, X_2, sd_sigma_y = c(1, 2), sd_sigma1 = 1, sd_beta2 = 1),
   "length(sd_sigma_y) == 1 is not TRUE",
   fixed = TRUE
 )
 expect_error(
-  fit_mixed(y, X_1, X_2, sd_sigma1 = c(1, 2)),
+  fit_mixed(y, X_1, X_2, sd_sigma1 = c(1, 2), sd_sigma_y = 1, sd_beta2 = 1),
   "length(sd_sigma1) == 1 is not TRUE",
   fixed = TRUE
 )
 expect_error(
-  fit_mixed(y, X_1, X_2, nnt = c(1, 2)),
+  fit_mixed(y, X_1, X_2, nnt = c(1, 2), sd_sigma_y = 1, sd_sigma1 = 1, sd_beta2 = 1),
   "length(nnt) == 1 is not TRUE",
   fixed = TRUE
 )
 
 
 # test contents of fit object ---------------------------------------------
-fit <- fit_mixed(y, X_1, X_2)
+fit <- fit_mixed(y, X_1, X_2, sd_sigma_y = 1, sd_sigma1 = 1, sd_beta2 = 1)
 
 expect_equal(names(fit), c("beta1", "beta2", "sigma", "cov", "errors", "time"))
 
@@ -156,34 +156,34 @@ expect_equal(fit1$cov, fit2$cov)
 
 # these are just sanity checks, nothing precise
 
-fit1 <- fit_mixed(y, X_1, X_2, sd_sigma_y = 10)
-fit2 <- fit_mixed(y, X_1, X_2, sd_sigma_y = .1)
+fit1 <- fit_mixed(y, X_1, X_2, sd_sigma_y = 10, sd_sigma1 = 1, sd_beta2 = 1)
+fit2 <- fit_mixed(y, X_1, X_2, sd_sigma_y = 0.1, sd_sigma1 = 1, sd_beta2 = 1)
 expect_true(all(fit1$sigma["sigma_y", ] > fit2$sigma["sigma_y", ]))
 
-fit1 <- fit_mixed(y, X_1, X_2, sd_sigma1 = 10)
-fit2 <- fit_mixed(y, X_1, X_2, sd_sigma1 = .1)
+fit1 <- fit_mixed(y, X_1, X_2, sd_sigma1 = 10, sd_sigma_y = 1, sd_beta2 = 1)
+fit2 <- fit_mixed(y, X_1, X_2, sd_sigma1 = 0.1, sd_sigma_y = 1, sd_beta2 = 1)
 expect_true(all(fit1$sigma["sigma_beta1", ] > fit2$sigma["sigma_beta1", ]))
 
 
 # test that results haven't changed ---------------------------------------
 
-# fit_dump <- fit_mixed(y, X_1, X_2)
+# fit_dump <- fit_mixed(y, X_1, X_2, sd_sigma_y = 1, sd_beta2 = 1, sd_sigma1 = 1)
 # dump("fit_dump", file = "inst/tinytest/answers/fit_mixed-01.R")
-fit <- fit_mixed(y, X_1, X_2)
+fit <- fit_mixed(y, X_1, X_2, sd_sigma_y = 1, sd_beta2 = 1, sd_sigma1 = 1)
 answer <- source("answers/fit_mixed-01.R", local = TRUE)$value
 fit$time <- answer$time <- NULL
 expect_equal(fit, answer, tolerance = 0.01)
 
-# fit_dump <- fit_mixed(y, X_1, X_2, sd_beta2 = 2, sd_sigma_y = 2, sd_sigma1 = 2)
+# fit_dump <- fit_mixed(y, X_1, X_2, sd_sigma_y = 2, sd_beta2 = 2, sd_sigma1 = 2)
 # dump("fit_dump", file = "inst/tinytest/answers/fit_mixed-02.R")
-fit <- fit_mixed(y, X_1, X_2, sd_beta2 = 2, sd_sigma_y = 2, sd_sigma1 = 2)
+fit <- fit_mixed(y, X_1, X_2, sd_sigma_y = 2, sd_beta2 = 2, sd_sigma1 = 2)
 answer <- source("answers/fit_mixed-02.R", local = TRUE)$value
 fit$time <- answer$time <- NULL
 expect_equal(fit, answer, tolerance = 0.01)
 
-# fit_dump <- fit_mixed(y, X_1, X_2, nnt = 80)
+# fit_dump <- fit_mixed(y, X_1, X_2, nnt = 80, sd_beta2 = 1, sd_sigma_y = 1, sd_sigma1 = 1)
 # dump("fit_dump", file = "inst/tinytest/answers/fit_mixed-03.R")
-fit <- fit_mixed(y, X_1, X_2, nnt = 80)
+fit <- fit_mixed(y, X_1, X_2, nnt = 80, sd_beta2 = 1, sd_sigma_y = 1, sd_sigma1 = 1)
 answer <- source("answers/fit_mixed-03.R", local = TRUE)$value
 fit$time <- answer$time <- NULL
 expect_equal(fit, answer, tolerance = 0.01)
@@ -196,7 +196,7 @@ expect_equal(fit, answer, tolerance = 0.01)
 n_runs <- 100
 has_NaNs <- rep(FALSE, n_runs)
 for (i in 1:n_runs) {
-  fit <- fit_mixed(y, X_1, X_2)
+  fit <- fit_mixed(y, X_1, X_2, sd_sigma_y = 1, sd_beta2 = 1, sd_sigma1 = 1)
   has_NaNs[i] <- any(sapply(fit, anyNA))
 }
 expect_true(sum(has_NaNs) == 0)

--- a/inst/tinytest/test_fit_mixed_formula.R
+++ b/inst/tinytest/test_fit_mixed_formula.R
@@ -2,28 +2,34 @@
 
 # valid formulas
 expect_silent(
-  fit_mixed_formula(mpg ~ (1 | cyl), data = mtcars)
+  fit_mixed_formula(mpg ~ (1 | cyl), data = mtcars,
+                    sd_sigma_y = 1, sd_sigma1 = 1, sd_beta2 = 1)
 )
 expect_silent(
-  fit_mixed_formula(mpg ~ (0 + wt | cyl), data = mtcars)
+  fit_mixed_formula(mpg ~ (0 + wt | cyl), data = mtcars,
+                    sd_sigma_y = 1, sd_sigma1 = 1, sd_beta2 = 1)
 )
 
 # currently invalid formulas
 expect_error(
-  fit_mixed_formula(mpg ~ (1 + wt | cyl), data = mtcars),
+  fit_mixed_formula(mpg ~ (1 + wt | cyl), data = mtcars,
+                    sd_sigma_y = 1, sd_sigma1 = 1, sd_beta2 = 1),
   "Currently only terms (1 | g) and (0 + x | g) are supported. (1 + x|g) is not yet implemented.",
   fixed = TRUE
 )
 expect_error(
-  fit_mixed_formula(mpg ~ (1 | cyl/gear), data = mtcars),
+  fit_mixed_formula(mpg ~ (1 | cyl/gear), data = mtcars,
+                    sd_sigma_y = 1, sd_sigma1 = 1, sd_beta2 = 1),
   "Only one varying term is currently supported."
 )
 expect_error(
-  fit_mixed_formula(mpg ~ (1|cyl) + (1|gear), data = mtcars),
+  fit_mixed_formula(mpg ~ (1|cyl) + (1|gear), data = mtcars,
+                    sd_sigma_y = 1, sd_sigma1 = 1, sd_beta2 = 1),
   "Only one varying term is currently supported."
 )
 expect_error(
-  fit_mixed_formula(mpg ~ (1 + wt|cyl) + (1|gear), data = mtcars),
+  fit_mixed_formula(mpg ~ (1 + wt|cyl) + (1|gear), data = mtcars,
+                    sd_sigma_y = 1, sd_sigma1 = 1, sd_beta2 = 1),
   "Only one varying term is currently supported."
 )
 
@@ -46,9 +52,11 @@ expect_warning(
 
 X2 <- model.matrix(~ wt + disp + factor(gear), data = mtcars)
 X1 <- model.matrix(~ 0 + as.factor(cyl), data = mtcars)
-fit <- fit_mixed(mtcars$mpg, X1, X2, nnt = 100, sd_beta2 = 10)
+fit <- fit_mixed(mtcars$mpg, X1, X2, nnt = 100,
+                 sd_beta2 = 10, sd_sigma_y = 1, sd_sigma1 = 1)
 fit_formula <- fit_mixed_formula(mpg ~ wt + disp + factor(gear) + (1|cyl),
-                                 data = mtcars, nnt = 100, sd_beta2 = 10)
+                                 data = mtcars, nnt = 100,
+                                 sd_beta2 = 10, sd_sigma_y = 1, sd_sigma1 = 1)
 
 # for beta1 avoid checking rownames (they will currently differ for beta1)
 expect_equal(fit_formula$beta1, fit$beta1, check.attributes = FALSE)
@@ -66,7 +74,7 @@ expect_equal(fit_formula$cov, fit$cov, check.attributes = FALSE)
 # so we use this as a sanity check
 if (requireNamespace("lme4", quietly = TRUE)) {
   fit <- fit_mixed_formula(mpg ~ wt + factor(gear) + (1|cyl), data = mtcars,
-                           sd_sigma1 = 3, sd_beta2 = 10, nnt = 100)
+                           sd_sigma_y = 1, sd_sigma1 = 3, sd_beta2 = 10, nnt = 100)
   fit_lmer <- lme4::lmer(mpg ~ wt + factor(gear) + (1|cyl), data = mtcars)
   expect_equal(
     fit$beta1$mean,

--- a/man/fit_mixed.Rd
+++ b/man/fit_mixed.Rd
@@ -4,16 +4,7 @@
 \alias{fit_mixed}
 \title{Fast normal-normal mixed effects model}
 \usage{
-fit_mixed(
-  y,
-  X1,
-  X2,
-  ...,
-  sd_sigma_y = 1,
-  sd_sigma1 = 1,
-  sd_beta2 = rep(1, ncol(X2)),
-  nnt = 10
-)
+fit_mixed(y, X1, X2, ..., sd_sigma_y, sd_sigma1, sd_beta2, nnt = 10)
 }
 \arguments{
 \item{y}{(vector) The outcome variable.}
@@ -27,18 +18,14 @@ model. Must have \code{length(y)} rows.}
 \item{...}{Currently for internal use only.}
 
 \item{sd_sigma_y}{(positive real) Scale parameter value for the prior on
-\eqn{\sigma_y}. The default is \code{1}, but we strongly recommend setting the
-value yourself.}
+\eqn{\sigma_y}.}
 
 \item{sd_sigma1}{(positive real) Scale parameter value for the prior on
-\eqn{\sigma1}. The default is \code{1}, but we strongly recommend setting the
-value yourself.}
+\eqn{\sigma1}.}
 
 \item{sd_beta2}{(positive reals) Scale parameter values for the priors on
 \eqn{\beta2} ("fixed effects" coefficients). Must have either one element
-or \code{ncol(X2)} elements. In the former case the value is recycled. The
-default is \code{1} for each element, but we strongly recommend setting the
-values yourself.}
+or \code{ncol(X2)} elements. In the former case the value is recycled.}
 
 \item{nnt}{(positive integer) Number of quadrature nodes in \eqn{\theta}
 direction as described in Greengard et al. (2022). We recommend increasing

--- a/man/fit_mixed_formula.Rd
+++ b/man/fit_mixed_formula.Rd
@@ -8,9 +8,9 @@ fit_mixed_formula(
   formula,
   data,
   ...,
-  sd_sigma_y = 1,
-  sd_sigma1 = 1,
-  sd_beta2 = 1,
+  sd_sigma_y,
+  sd_sigma1,
+  sd_beta2,
   nnt = 10
 )
 }
@@ -25,18 +25,14 @@ effects" part of the model formula. To bypass this restriction use
 \item{...}{Currently for internal use only.}
 
 \item{sd_sigma_y}{(positive real) Scale parameter value for the prior on
-\eqn{\sigma_y}. The default is \code{1}, but we strongly recommend setting the
-value yourself.}
+\eqn{\sigma_y}.}
 
 \item{sd_sigma1}{(positive real) Scale parameter value for the prior on
-\eqn{\sigma1}. The default is \code{1}, but we strongly recommend setting the
-value yourself.}
+\eqn{\sigma1}.}
 
 \item{sd_beta2}{(positive reals) Scale parameter values for the priors on
 \eqn{\beta2} ("fixed effects" coefficients). Must have either one element
-or \code{ncol(X2)} elements. In the former case the value is recycled. The
-default is \code{1} for each element, but we strongly recommend setting the
-values yourself.}
+or \code{ncol(X2)} elements. In the former case the value is recycled.}
 
 \item{nnt}{(positive integer) Number of quadrature nodes in \eqn{\theta}
 direction as described in Greengard et al. (2022). We recommend increasing

--- a/tests/stan-comparison/compare_fit_mixed.R
+++ b/tests/stan-comparison/compare_fit_mixed.R
@@ -17,7 +17,11 @@ sd_sigma_y <- 1.0
 sd_sigma1 <- 2.0
 
 # Stan posterior means and sds --------------------------------------------
-data_list <- list(n=n, k1=k1, k2=k2, y=y, sd_beta2=sd_beta2, sd_sigma_y=sd_sigma_y, sd_sigma1=sd_sigma1, X1=X1, X2=X2)
+data_list <- list(
+  n = n, k1 = k1, k2 = k2,
+  y = y, X1 = X1, X2 = X2,
+  sd_beta2 = sd_beta2, sd_sigma_y = sd_sigma_y, sd_sigma1 = sd_sigma1
+)
 mod <- cmdstan_model("tests/stan-comparison/fit_mixed.stan")
 fit_stan <- mod$sample(data = data_list, seed = 1, parallel_chains = 4, iter_sampling = 1e4)
 posterior_summary <- fit_stan$summary()[-1, ] # drop lp__


### PR DESCRIPTION
Based on our discussion today, this PR removes the default values for `sd_sigma_y`, `sd_sigma1`, and `sd_beta2`. 